### PR TITLE
Add newline when concatting code

### DIFF
--- a/live-compile.jsx
+++ b/live-compile.jsx
@@ -43,7 +43,7 @@ var ComponentPreview = React.createClass({
           '/** @jsx React.DOM */' +
           '(function() {' +
               this.props.code +
-          '})();',
+          '\n})();',
       { harmony: true }
       ).code;
     },


### PR DESCRIPTION
this.props.code could end without a newline, in which case we need to add one to avoid syntax errors.

See https://github.com/Khan/react-components/issues/2.
